### PR TITLE
Fix load error on release

### DIFF
--- a/.changeset/chatty-cobras-tan.md
+++ b/.changeset/chatty-cobras-tan.md
@@ -1,0 +1,5 @@
+---
+"recursica-forge": patch
+---
+
+Fix load error on new release

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -61,6 +61,12 @@ if (typeof window !== 'undefined') {
       event.preventDefault()
     }
   })
+
+  // Handle Vite chunk load errors gracefully (e.g. after a new deploy)
+  window.addEventListener('vite:preloadError', (event) => {
+    event.preventDefault()
+    window.location.reload()
+  })
 }
 
 // Initialize theme before React mounts


### PR DESCRIPTION
When new releases are made, we get a load error and the user has to refresh.  Catch this condition and do the reload automatically for them